### PR TITLE
Add routine to get message loop thread id

### DIFF
--- a/pkg/winquit/server.go
+++ b/pkg/winquit/server.go
@@ -32,3 +32,14 @@ func NotifyOnQuit(done chan bool) {
 func SimulateSigTermOnQuit(handler chan os.Signal) {
 	simulateSigTermOnQuit(handler)
 }
+
+// Returns the thread id of the message loop thread created by winquit, or "0"
+// if one is not running. The latter indicates a mistake, as this function
+// should only be called after a call to one of the _OnQuit functions.
+//
+// In most cases this method should not be necessary, as RequestQuit and
+// QuitProcess do not require it. It is primarily provided to enable legacy
+// patterns that serialize the thread id for later direct signaling.
+func GetCurrentMessageLoopThreadId() uint32 {
+	return getCurrentMessageLoopThreadId()
+}

--- a/pkg/winquit/server_unsupported.go
+++ b/pkg/winquit/server_unsupported.go
@@ -12,3 +12,7 @@ func notifyOnQuit(done chan bool) {
 
 func simulateSigTermOnQuit(handler chan os.Signal) {
 }
+
+func getCurrentMessageLoopThreadId() uint32 {
+	return 0
+}

--- a/pkg/winquit/server_windows.go
+++ b/pkg/winquit/server_windows.go
@@ -81,7 +81,7 @@ func messageLoop() {
 
 	registerDummyWindow()
 
-	logrus.Info("Entering loop for quit")
+	logrus.Debug("Entering loop for quit")
 	for {
 		ret, msg, err := win32.GetMessage(0, 0, 0)
 		if err != nil {

--- a/pkg/winquit/server_windows.go
+++ b/pkg/winquit/server_windows.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/winquit/pkg/winquit/win32"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 type receiversType struct {
@@ -25,6 +26,7 @@ var (
 	}
 
 	loopInit sync.Once
+	loopTid  uint32
 )
 
 func (r *receiversType) add(channel baseChannelType) {
@@ -75,10 +77,15 @@ func simulateSigTermOnQuit(handler chan os.Signal) {
 	initLoop()
 }
 
+func getCurrentMessageLoopThreadId() uint32 {
+	return loopTid
+}
+
 func messageLoop() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
+	loopTid = windows.GetCurrentThreadId()
 	registerDummyWindow()
 
 	logrus.Debug("Entering loop for quit")


### PR DESCRIPTION
Adds new API for compatibility with use-cases that wish to serialize the thread id of the message loop thread.